### PR TITLE
Informação de executores tratada e adicionada no campo de informações gerais

### DIFF
--- a/backend/app/services/api_consumer.py
+++ b/backend/app/services/api_consumer.py
@@ -100,6 +100,15 @@ class ObraAPIConsumer:
 
         for obra_data in obras_data:
             try:
+                # Extração de "descricao" dentro de "tipos"
+                tipos = obra_data.get('tipos', [])
+                descricao_tipo = tipos[1]['descricao'] if tipos else "Não informado" 
+
+                # Extração de "nome" dentro de "executores"
+                executores = obra_data.get('executores', [])
+                nome_executor = executores[0]['nome'] if executores else "Não informado"
+
+
                 data_inicial = obra_data.get('dataInicialPrevista')
                 data_final = obra_data.get('dataFinalPrevista')
                 
@@ -119,8 +128,8 @@ class ObraAPIConsumer:
                     'nome': obra_data.get('nome'),
                     'uf': obra_data.get('uf'),
                     'situacao': obra_data.get('situacao', 'Não informada'),
-                    'tipo': self._determine_tipo(obra_data),
-                    'executores': obra_data.get('executores', []),
+                    'tipo': descricao_tipo,
+                    'executores': nome_executor,
                     'natureza': obra_data.get('natureza', 'Não informada'),
                     'endereco': self._sanitize_endereco(obra_data.get('endereco')),
                     'funcaoSocial': obra_data.get('funcaoSocial', 'Não informada'),
@@ -160,3 +169,4 @@ class ObraAPIConsumer:
             'error_count': error_count,
             'errors': errors
         }
+

--- a/backend/app/views/view_obra.py
+++ b/backend/app/views/view_obra.py
@@ -98,6 +98,7 @@ def get_obras_coordinates():
                         'longitude': coords[1],
                         'tipo': obra.tipo,
                         'situacao': obra.situacao,
+                        'executores': obra.executores,
                         'valorInvestimentoPrevisto': obra.valorInvestimentoPrevisto,
                         'original_wkt': obra.geometria
                     })
@@ -140,6 +141,7 @@ def get_obra_coordinates(obra_id: int):
                 'longitude': coords[1],
                 'tipo': obra.tipo,
                 'situacao': obra.situacao,
+                'executores': obra.executores,
                 'valorInvestimentoPrevisto': obra.valorInvestimentoPrevisto,
                 'original_wkt': obra.geometria
             }

--- a/frontend/src/hooks/useObras.tsx
+++ b/frontend/src/hooks/useObras.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react';
 import axios from 'axios';
 
+
+
 export interface ObraCoordinates {
   id: number;
   nome: string;
@@ -8,6 +10,7 @@ export interface ObraCoordinates {
   longitude: number;
   tipo: string;
   situacao: string;
+  executor: string;
   valorInvestimentoPrevisto: number;
   original_wkt: string;
 }
@@ -31,7 +34,14 @@ export const useObrasCoordinates = (): UseObrasCoordinatesReturn => {
       setLoading(true);
       const response = await axios.get(`${API_URL}/coordinates`);
       if (response.data.success) {
-        setObras(response.data.data);
+  
+        const obrasData = response.data.data.map((obra: any) => ({
+          ...obra,
+          executor: obra.executores
+            ? obra.executores.map((e: any) => e.nome).join(', ')
+            : 'Não informado', 
+        }));
+        setObras(obrasData);
         setError(null);
       } else {
         setError('Erro ao carregar coordenadas das obras');
@@ -43,6 +53,7 @@ export const useObrasCoordinates = (): UseObrasCoordinatesReturn => {
       setLoading(false);
     }
   };
+  
 
   useEffect(() => {
     fetchObras();
@@ -50,3 +61,4 @@ export const useObrasCoordinates = (): UseObrasCoordinatesReturn => {
 
   return { obras, loading, error, refetch: fetchObras };
 };
+

--- a/frontend/src/pages/InformacoesGerais.tsx
+++ b/frontend/src/pages/InformacoesGerais.tsx
@@ -14,6 +14,7 @@ interface ObraDetails {
   longitude: number;
   tipo: string;
   situacao: string;
+  executor: string;
   valorInvestimentoPrevisto: number;
   original_wkt: string;
 }
@@ -32,7 +33,13 @@ export default function InformacoesGerais() {
           `http://localhost:5000/obras/${obraId}/coordinates`
         );
         if (response.data.success) {
-          setObra(response.data.data);
+          const obraData = response.data.data;
+          setObra({
+            ...obraData,
+            executor: obraData.executores
+              ? obraData.executores.map((e: any) => e.nome).join(', ')
+              : 'Não informado', 
+          });
           setError(null);
         } else {
           setError("Erro ao carregar detalhes da obra.");
@@ -44,9 +51,10 @@ export default function InformacoesGerais() {
         setLoading(false);
       }
     };
-
+  
     fetchObraDetails();
   }, [obraId]);
+  
 
   if (loading) {
     return <div>Carregando...</div>;
@@ -83,6 +91,7 @@ export default function InformacoesGerais() {
         <p>Nome: {obra.nome}</p>
         <p>Tipo: {obra.tipo}</p>
         <p>Situação: {obra.situacao}</p>
+        <p>Executor: {obra.executor}</p>
         <p>Valor Investido: R$ {obra.valorInvestimentoPrevisto.toLocaleString('pt-BR')}</p>
         <div className="info-btn">
           <button onClick={() => navigate("/mapa")}>SAIR</button>
@@ -91,3 +100,4 @@ export default function InformacoesGerais() {
     </div>
   );
 }
+

--- a/frontend/src/pages/MapaGeral.tsx
+++ b/frontend/src/pages/MapaGeral.tsx
@@ -143,6 +143,7 @@ export default function MapInterface() {
                   <h3 className="font-bold">{obra.nome}</h3>
                   <p>Tipo: {obra.tipo}</p>
                   <p>Situação: {obra.situacao}</p>
+                  <p>Executor: {obra.executor}</p>
                   <p>Valor: R$ {obra.valorInvestimentoPrevisto.toLocaleString('pt-BR')}</p>
                 </div>
               </Popup>


### PR DESCRIPTION
**Descrição**

Este pull request corrige o retorno do endpoint "executores" e adiciona esse campo em infomações gerais de obras.

**Principais alterações:**

- **Correção da rota de backend:**
  - Ajuste na rota "/<int:obra_id>/coordinates" para receber o campo executor.
  - Retorna somente o nome do executor, pois na API o retorno é um dicionário
  
- **Ajustes no hook `useObrasCoordinates`:**
  - No hook useObrasCoordinates, o campo executor agora será populado com uma string contendo os nomes concatenados dos executores ou "Não informado" caso esteja vazio.
  
- **Atualização do componente `MapaGeral`:**
  - Configuração de redirecionamento dinâmico para a página de informações gerais ao clicar em um marcador.
  
- **Atualização do componente `InformacoesGerais`:**
  - O mesmo tratamento é aplicado para garantir consistência.

**Motivação**

Exibir o executor de cada obra, em informações gerais, porem o endpoint da API que retorna essa informação é um dicionário com dois valores, com isso, antes executores era tratado como um objeto de único valor, mas agora somente a informação do nome do executor é trazida do banco de dados

**Checklist**

- [x] Ajuste da rota no backend para retornar o nome do executor..
- [x] Exibição do nome do executor na pagina Informações Gerais.
- [x] Rota "/<int:obra_id>/coordinates" retorna o dicionário de executores.

**Dependências**

- Nenhuma nova dependência foi adicionada.

**Impacto esperado**

- Os usuários agora podem clicar nos ícones das obras no mapa e acessar informações detalhadas, como ID, tipo, endereço e valor investido e agora quem executa a obra.

