### PR TITLE
Junção de todos os Filtros em uma única rota(endpoint)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,6 +12,7 @@ RUN pip install --no-cache-dir numpy
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
+COPY regioesAdm.json /app/regioesAdm.json
 
 ENV FLASK_APP=run.py
 ENV FLASK_ENV=development

--- a/backend/app/views/geojson.py
+++ b/backend/app/views/geojson.py
@@ -1,0 +1,22 @@
+# geojson.py
+import json
+from shapely.geometry import shape
+from flask import current_app
+
+def normalize_region_name(region: str) -> str:
+    return "".join(region.split()).lower()
+
+def load_ra_geometries():
+    
+    geojson_path = "/app/regioesAdm.json"
+    with open(geojson_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    
+    ra_geometries = {}
+    for feature in data.get("features", []):
+        
+        ra_value = feature.get("properties", {}).get("ra")
+        if ra_value:
+            normalized_ra = normalize_region_name(ra_value)
+            ra_geometries[normalized_ra] = shape(feature["geometry"])
+    return ra_geometries

--- a/backend/app/views/view_obra.py
+++ b/backend/app/views/view_obra.py
@@ -12,7 +12,9 @@ from binascii import unhexlify
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy import func
 from flask import jsonify, request
-
+from flask import current_app
+from .geojson import load_ra_geometries
+from shapely.geometry import Point
 
 obra_bp = Blueprint('obras', __name__)
 
@@ -254,4 +256,67 @@ def get_tipos():
     
     except Exception as e:
         print(f"Error in get_tipos: {str(e)}")
+        return jsonify({'success': False, 'error': str(e)}), 500
+    
+@obra_bp.before_app_first_request
+def setup_ra_geometries():
+    current_app.config['RA_GEOMETRIES'] = load_ra_geometries()
+
+
+@obra_bp.route('/filterRegion', methods=['GET'])
+@cross_origin()
+def filter_by_region():
+    try:
+        
+        regions = request.args.getlist('regions')
+        if not regions:
+            regions = request.args.getlist('regions[]')
+        if not regions:
+            return jsonify({'success': False, 'error': 'Nenhuma região foi selecionada'}), 400
+
+        # Função de normalização (pode ser importada ou redefinida aqui)
+        def normalize_region_name(region: str) -> str:
+            return "".join(region.split()).lower()
+        
+        # Normaliza os valores recebidos
+        regions = [normalize_region_name(r) for r in regions]
+
+        
+        ra_geometries = current_app.config.get('RA_GEOMETRIES')
+        if not ra_geometries:
+            return jsonify({'success': False, 'error': 'GeoJSON das RA não foi carregado'}), 500
+
+        obras = Obra.query.all()
+        filtered_obras = []
+
+        for obra in obras:
+            if not obra.geometria:
+                continue
+            # converte a geometria para coordenadas (latitude, longitude)
+            coords = parse_wkt_to_coordinates(obra.geometria)
+            if not coords:
+                continue
+
+
+            point = Point(coords[1], coords[0])  # (lon, lat)
+
+            # verifica se o ponto tá contido em alguma das regiões selecionadas
+            for region in regions:
+                polygon = ra_geometries.get(region)
+                if polygon and polygon.contains(point):
+                    filtered_obras.append({
+                        'id': obra.id,
+                        'nome': obra.nome,
+                        'valorInvestimentoPrevisto': obra.valorInvestimentoPrevisto,
+                        'situacao': obra.situacao,
+                        'tipo': obra.tipo,
+                        'executor': obra.executores,
+                        'latitude': coords[0],
+                        'longitude': coords[1]
+                    })
+                    break  # Se estiver dentro de uma das regiões selecionadas, não precisa testar as demais
+
+        return jsonify({'success': True, 'data': filtered_obras})
+    except Exception as e:
+        print(f"Error in filter_by_region: {str(e)}")
         return jsonify({'success': False, 'error': str(e)}), 500

--- a/backend/app/views/view_obra.py
+++ b/backend/app/views/view_obra.py
@@ -164,15 +164,15 @@ def get_obra_coordinates(obra_id: int):
 @cross_origin()
 def filter_obras():
     try:
-        tipo = request.args.get('tipo')
+        tipos = request.args.getlist('tipo')  
         situacao = request.args.get('situacao')
         valores = request.args.getlist('valores[]')
         executores = request.args.get('executores')  
 
         query = Obra.query
 
-        if tipo:
-            query = query.filter(Obra.tipo == tipo)
+        if tipos:  
+            query = query.filter(Obra.tipo.in_(tipos))
         if situacao:
             query = query.filter(Obra.situacao == situacao)
         if executores:
@@ -239,4 +239,19 @@ def get_executores():
         return jsonify({'success': True, 'data': executores})
     except Exception as e:
         print(f"Error in get_executores: {str(e)}")
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+# esse endpoint puxa todos os tipos(distintos) de obras que tem no banco
+@obra_bp.route('/tipos', methods=['GET'])
+@cross_origin()
+def get_tipos():
+    try:
+        tipos = db.session.query(Obra.tipo.distinct()).all()
+        
+        tipos = [t[0] for t in tipos] 
+        
+        return jsonify({'success': True, 'data': tipos})
+    
+    except Exception as e:
+        print(f"Error in get_tipos: {str(e)}")
         return jsonify({'success': False, 'error': str(e)}), 500

--- a/frontend/src/pages/FiltroRegiao.tsx
+++ b/frontend/src/pages/FiltroRegiao.tsx
@@ -1,32 +1,55 @@
+// FiltroRegiao.tsx (modificação)
+import { useState } from "react";
 import { MapContainer, TileLayer } from 'react-leaflet';
-import 'leaflet/dist/leaflet.css';
+import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
 import "../styles/Filtros.css";
 import Logo from "../components/Logo";
-import { useState } from "react";
+
+const regioesAdministrativas = [
+  "Plano Piloto", "Gama", "Brazlândia", "Candangolândia",
+  "Riacho Fundo II", "Riacho Fundo", "Recanto das Emas", "Lago Sul",
+  "Planaltina", "Paranoá", "Guará", "Samambaia", "Santa Maria",
+  "São Sebastião", "Park Way", "Sobradinho II", "Jardim Botânico",
+  "Vicente Pires", "SIA", "Águas Claras", "Ceilândia", "Fercal",
+  "Taguatinga", "Pôr do Sol", "Arniqueira", "Sudoeste/Octogonal",
+  "Varjão", "Núcleo Bandeirante", "Cruzeiro", "Lago Norte",
+  "SCIA", "Itapoã"
+];
 
 export default function FiltroRegiao() {
-  const position = [-15.7801, -47.9292];
-  const [statusFiltro, setStatusFiltro] = useState<string[]>([]); 
+  const [statusFiltro, setStatusFiltro] = useState<string[]>([]);
+  const navigate = useNavigate();
 
   const handleCheckboxChange = (value: string) => {
     setStatusFiltro((prev) =>
-      prev.includes(value)
-        ? prev.filter((item) => item !== value) 
-        : [...prev, value] 
+      prev.includes(value) ? prev.filter((item) => item !== value) : [...prev, value]
     );
   };
 
   const limparFiltros = () => {
-    setStatusFiltro([]); 
+    setStatusFiltro([]);
   };
+
+  const handleConcluir = async () => {
+    try {
+      const response = await axios.get('http://localhost:5000/obras/filterRegion', {
+        params: { regions: statusFiltro }
+      });
+      if (response.data.success) {
+        // Navega para a tela do mapa, passando as obras filtradas via state
+        navigate("/mapa", { state: { filteredObras: response.data.data } });
+      }
+    } catch (error) {
+      console.error("Erro ao filtrar obras por região:", error);
+    }
+  };
+
+  const position = [-15.7801, -47.9292];
 
   return (
     <div className="relative h-screen w-full">
-      <MapContainer
-        center={position}
-        zoom={10}
-        style={{ height: '100%', width: '100%' }}
-      >
+      <MapContainer center={position} zoom={10} style={{ height: '100%', width: '100%' }}>
         <TileLayer
           url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
           attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
@@ -35,97 +58,24 @@ export default function FiltroRegiao() {
 
       <Logo />
       <div className="filter-container">
-        <h1>ESCOLHA A REGIÃO</h1>
-
+        <h1>ESCOLHA A REGIÃO ADMINISTRATIVA</h1>
         <div className="checkbox-filter region">
-          <label>
-            <input
-              type="checkbox"
-              value="norte"
-              checked={statusFiltro.includes("norte")}
-              onChange={() => handleCheckboxChange("norte")}
-            />
-            Região Norte
-          </label>
-
-          <label>
-            <input
-              type="checkbox"
-              value="sul"
-              checked={statusFiltro.includes("sul")}
-              onChange={() => handleCheckboxChange("sul")}
-            />
-            Região Sul
-          </label>
-
-          <label>
-            <input
-              type="checkbox"
-              value="leste"
-              checked={statusFiltro.includes("leste")}
-              onChange={() => handleCheckboxChange("leste")}
-            />
-            Região Leste
-          </label>
-
-          <label>
-            <input
-              type="checkbox"
-              value="oeste"
-              checked={statusFiltro.includes("oeste")}
-              onChange={() => handleCheckboxChange("oeste")}
-            />
-            Região Oeste
-          </label>
-
-          <label>
-            <input
-              type="checkbox"
-              value="nordeste"
-              checked={statusFiltro.includes("nordeste")}
-              onChange={() => handleCheckboxChange("nordeste")}
-            />
-            Região Nordeste
-          </label>
-
-          <label>
-            <input
-              type="checkbox"
-              value="noroeste"
-              checked={statusFiltro.includes("noroeste")}
-              onChange={() => handleCheckboxChange("noroeste")}
-            />
-            Região Noroeste
-          </label>
-
-          <label>
-            <input
-              type="checkbox"
-              value="sudeste"
-              checked={statusFiltro.includes("sudeste")}
-              onChange={() => handleCheckboxChange("sudeste")}
-            />
-            Região Sudeste
-          </label>
-
-          <label>
-            <input
-              type="checkbox"
-              value="sudoeste"
-              checked={statusFiltro.includes("sudoeste")}
-              onChange={() => handleCheckboxChange("sudoeste")}
-            />
-            Região Sudoeste
-          </label>
+          {regioesAdministrativas.map((ra) => (
+            <label key={ra}>
+              <input
+                type="checkbox"
+                value={ra}
+                checked={statusFiltro.includes(ra)}
+                onChange={() => handleCheckboxChange(ra)}
+              />
+              {ra}
+            </label>
+          ))}
         </div>
 
         <div className="filter-btn">
-          <button className="clean-btn" onClick={limparFiltros}>
-            LIMPAR
-          </button>
-          <button className="check-btn">
-            CONCLUIR
-          </button>
+          <button className="clean-btn" onClick={limparFiltros}>LIMPAR</button>
+          <button className="check-btn" onClick={handleConcluir}>CONCLUIR</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Junção de todos os Filtros em uma única rota(endpoint)

## Descrição  
O filtro de tipos de obras está em outro arquivo e endpoint. Decidimos consolidar todos os filtros em um único endpoint. A rota /filterExec retorna um JSON com as obras filtradas de acordo com os parâmetros passados na URL. Por exemplo, a URL "http://localhost:5000/obras/filterExec?executores=DEPARTAMENTO A" retorna todas as obras cujo executor seja o DEPARTAMENTO A.

Se a lógica de filtros por tipos de obras for adicionada ao mesmo endpoint, poderemos usar a mesma URL para filtrar também por tipo. Por exemplo: "http://localhost:5000/obras/filterExec?tipo=Educação".

Outro problema identificado está relacionado às opções de tipos de obras disponíveis para o usuário. Atualmente, essas opções são definidas manualmente no código, mas é possível implementar uma solução mais eficiente. No filtro de executores, por exemplo, o endpoint /executores retorna todos os executores distintos presentes no banco de dados, permitindo que o usuário visualize todas as opções disponíveis de forma automatizada. Essa mesma lógica pode ser aplicada ao filtro de tipos de obras, tornando o sistema mais dinâmico e menos suscetível a erros manuais.


## Comportamento esperado  
Todos os filtros em um mesmo arquivo e no mesmo endpoint.

## Comportamento atual  
Agora todos os filtros de tipo, valor e executor está em um unico endpoint.

